### PR TITLE
Replaces the "openid profile" scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can obtain a delegation token specifying the ID of the target client (`targe
 var targetClientId = "{TARGET_CLIENT_ID}";
 var options = new Dictionary<string, string>
 {
-    { "scope", "openid profile" },		// default: openid
+    { "scope", "openid name email" },		// default: openid // Details: https://auth0.com/docs/scopes
     { "id_token", "USER_ID_TOKEN" }		// default: id_token of the authenticated user (auth0.CurrentUser.IdToken)
 };
 

--- a/SampleApp.Phone81/MainPage.xaml.cs
+++ b/SampleApp.Phone81/MainPage.xaml.cs
@@ -68,7 +68,7 @@ namespace SampleApp.Phone81
                 var targetClientId = "HmqDkk9qtDgxsiSKpLKzc51xD75hgiRW";
                 var options = new Dictionary<string, string>
                 {
-                    { "scope", "openid profile" }
+                    { "scope", "openid name email" }
                 };
 
                 var delegationResult = await auth0.GetDelegationToken(targetClientId, options);

--- a/SampleApp/MainPage.xaml.cs
+++ b/SampleApp/MainPage.xaml.cs
@@ -52,7 +52,7 @@ namespace SampleApp
                 var targetClientId = "HmqDkk9qtDgxsiSKpLKzc51xD75hgiRW";
                 var options = new Dictionary<string, string>
                 {
-                    { "scope", "openid profile" }
+                    { "scope", "openid name email" }
                 };
 
                 var delegationResult = await auth0.GetDelegationToken(targetClientId, options);


### PR DESCRIPTION
The currently recommended scope is "openid name email".